### PR TITLE
Fix WriteOsuString function

### DIFF
--- a/osu-buffer.js
+++ b/osu-buffer.js
@@ -452,7 +452,7 @@ class OsuBuffer {
             this.WriteByte(0);
         } else {
             this.WriteByte(11);
-            this.WriteVarint(value.length);
+            this.WriteVarint(Buffer.byteLength(value, 'utf8'));
             this.WriteString(value);
         }
         return this;


### PR DESCRIPTION
Fixed a problem where certain characters were truncated by passing the length of the byte rather than the length of the character