### PR TITLE
Fix for 64 bit Ints

### DIFF
--- a/osu-buffer.js
+++ b/osu-buffer.js
@@ -368,10 +368,7 @@ class OsuBuffer {
      */
     WriteUInt64(value) {
         let buff = Buffer.alloc(8);
-        // High
-        buff.writeUInt32LE(value >> 8, 0);
-        // Low
-        buff.writeUInt32LE(value & 0x00ff, 4);
+        buff.writeBigUInt64LE(BigInt(value), 0);
 
         return this.WriteBuffer(buff);
     }
@@ -383,10 +380,7 @@ class OsuBuffer {
      */
     WriteInt64(value) {
         let buff = Buffer.alloc(8);
-        // High
-        buff.writeInt32LE(value >> 8, 0);
-        // Low
-        buff.writeInt32LE(value & 0x00ff, 4);
+        buff.writeBigInt64LE(BigInt(value), 0);
 
         return this.WriteBuffer(buff);
     }


### PR DESCRIPTION
I was having issues with 64 bit Ints specifically for ranked and total score.
`writeBigInt64LE` and `writeBigUInt64LE` have been in node since v12

Ranked Score being sent:
![image](https://user-images.githubusercontent.com/37120476/113703728-26e8f800-96d3-11eb-8154-5b64397a63dd.png)

master:
![image](https://user-images.githubusercontent.com/37120476/113703653-0b7ded00-96d3-11eb-9a11-61a2f1e846d5.png)
This pr:
![image](https://user-images.githubusercontent.com/37120476/113703674-12a4fb00-96d3-11eb-9877-00d27abf3827.png)
